### PR TITLE
Undefined name 'pin_memory_batch'

### DIFF
--- a/lib/prosr/data/multiproc.py
+++ b/lib/prosr/data/multiproc.py
@@ -1,9 +1,10 @@
 import torch
 import torch.multiprocessing as multiprocessing
-from torch.utils.data.dataloader import _DataLoaderIter, DataLoader, \
-    _worker_manager_loop, _set_SIGCHLD_handler, ExceptionWrapper
-from torch._C import _set_worker_signal_handlers, _update_worker_pids, \
-    _remove_worker_pids, _error_if_any_worker_fails
+from torch.utils.data.dataloader import (_DataLoaderIter, DataLoader,
+    _worker_manager_loop, _set_SIGCHLD_handler, ExceptionWrapper,
+    pin_memory_batch)
+from torch._C import (_set_worker_signal_handlers, _update_worker_pids,
+    _remove_worker_pids, _error_if_any_worker_fails)
 import random
 import threading
 import sys
@@ -198,4 +199,3 @@ class MyDataLoader(DataLoader):
 
     def __len__(self):
         return len(self.batch_sampler)
-


### PR DESCRIPTION
https://github.com/pytorch/pytorch/blob/master/torch/utils/data/dataloader.py#L199

flake8 testing of https://github.com/fperazzi/proSR on Python 3.7.0

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./lib/prosr/data/multiproc.py:131:25: F821 undefined name 'pin_memory_batch'
                batch = pin_memory_batch(batch)
                        ^
1     F821 undefined name 'pin_memory_batch'
1
```