### PR TITLE
Fix calculating ssim value.

### DIFF
--- a/lib/prosr/metrics.py
+++ b/lib/prosr/metrics.py
@@ -33,6 +33,7 @@ def eval_psnr_and_ssim(im1, im2, scale):
         win_size=11,
         gaussian_weights=True,
         multichannel=True,
+        data_range=1.0,
         K1=0.01,
         K2=0.03,
         sigma=1.5)


### PR DESCRIPTION
data_range is required, due to the fact that library infers it on its own. Documentation says "By default, this is estimated from the image data-type.". I have tested it on this paper results: http://www.vision.ee.ethz.ch/~timofter/publications/Agustsson-CVPRW-2017suppl.pdf  . Without data_range it returns incorrect values, because of wrong range inference. With this fix, it seems to be working.