### PR TITLE
Bugfixes and monkeypatch

### DIFF
--- a/lib/prosr/models/trainer.py
+++ b/lib/prosr/models/trainer.py
@@ -243,8 +243,11 @@ class SimultaneousMultiscaleTrainer(object):
 
         # Load more params
         self.start_epoch = data['epoch']
+        # update progress, otherwise we always restart training from first defined scale
+        self.progress = self.start_epoch / self.opt.train.epochs
         self.lr = data['lr']
-
+        # update learning rate to take into account current epoch/progress
+        self.update_learning_rate()
         info('loaded optimizer state from ' + save_path)
 
     def set_learning_rate(self, lr, optimizer):

--- a/lib/prosr/utils/misc.py
+++ b/lib/prosr/utils/misc.py
@@ -123,7 +123,12 @@ def mkdir(path):
 def print_current_errors(epoch, i, errors, t, log_name=None):
     message = '(epoch: %d, iters: %d, time: %.3f) ' % (epoch, i, t)
     for k, v in errors.items():
-        message += '%s: %.3f ' % (k, v)
+        # v is sometimes a list TODO: fix error at the source
+        if isinstance(v, list):
+            err = np.add(err, v).sum() / len(v)
+        else:
+            err = v
+        message += '%s: %.3f ' % (k, err)
 
     print(message)
     if log_name is not None:


### PR DESCRIPTION
bug fix to properly resume training at last trained scale when loading optimizer
monkey-patch to avoid crash when printing errors during multiscale/curriculum training when more than one scales are trained "simultaneously"