### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM pytorch/pytorch:0.4-cuda9-cudnn7-devel
+
+RUN conda update -n base conda
+
+# Install image libraries
+RUN conda install scikit-image cython
+
+# Install visdom
+RUN conda install visdom dominate -c conda-forge
+
+RUN pip install easydict
+RUN apt-get update \
+  && apt-get install -y unzip \
+  && apt-get clean
+
+WORKDIR /proSR
+
+# Download the pretrained models from https://www.dropbox.com/s/3fjp5dd70wuuixl/proSR.zip?dl=0
+RUN mkdir data \
+  && curl "https://uc3b1ac4fd89b8faade327413784.dl.dropboxusercontent.com/cd/0/get/Asc95ggr2ND1PSdArswBOAHZSVD81uKKJUSh4DkwnFEsotIY0GxBQV6u5Qk2qq9MzMf_LRwpbSqUwLjdS3e7cJBiCamP2GfEJLYaj1IFbCuY8A/file?_download_id=4106874430186797740972858684583935099590670666545264828231381385131&_notify_domain=www.dropbox.com&dl=1" > data/proSR.zip \
+  && unzip -d data data/proSR.zip \
+  && rm data/proSR.zip
+  
+COPY . .
+
+ENV PYTHONPATH=/proSR/lib:$PYTHONPATH
+

--- a/README.md
+++ b/README.md
@@ -143,6 +143,14 @@ python test.py -i LR_INPUT (optional) -t HR_INPUT (optional) --checkpoint CHECKP
 python test.py --checkpoint data/checkpoints/proSR.pth --target data/datasets/DIV2K/DIV2K_valid_HR --scale 8
 ```
 
+
+#### Docker example
+```bash
+nvidia-docker build -t prosr .
+nvidia-docker run -it --name prosr --shm-size=4G -v INPUT_DATA/:/data prosr \
+    python test.py -i data/input --checkpoint data/proSR/proSR_x8.pth --scale -o /data/output
+```
+
 ## Additional Tools
 
 ### Configuration
@@ -150,7 +158,7 @@ python test.py --checkpoint data/checkpoints/proSR.pth --target data/datasets/DI
 The configuration file and the command-line options are embedded as a dictionary in the respective *.pth. file. Print the configuration file using the command:
 
 ```
-python tools/print_info.py --config data/checkpoints/proSR.pth
+python tools/print_info.py data/checkpoints/proSR.pth
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -146,9 +146,12 @@ python test.py --checkpoint data/checkpoints/proSR.pth --target data/datasets/DI
 
 #### Docker example
 ```bash
+# Build the image with GPU support
 nvidia-docker build -t prosr .
+
+# Scale a folder by 8x
 nvidia-docker run -it --name prosr --shm-size=4G -v INPUT_DATA/:/data prosr \
-    python test.py -i data/input --checkpoint data/proSR/proSR_x8.pth --scale -o /data/output
+    python test.py -i /data --checkpoint data/proSR/proSR_x8.pth --scale 8 -o /data/output
 ```
 
 ## Additional Tools


### PR DESCRIPTION
This PR adds a Dockerfile that runs the setup directions from the README and downloads the folder of pretrained models from the Dropbox link.

Lastly, fix the `print_info` invocation directions.